### PR TITLE
JASP instructions h10

### DIFF
--- a/h10kansverdelingen.Rmd
+++ b/h10kansverdelingen.Rmd
@@ -289,6 +289,15 @@ $\sigma = \sqrt{n \times p \times (1-p)} = \sqrt{ 3 \times .38 \times .62} = 0.8
 
 ---
 
+### JASP
+
+De binomiale kansverdeling van Figuur \@ref(fig:binomkansverdeling3) kan in JASP worden verkregen door in de bovenbalk te klikken op:
+```
+Distributions > Binomial (onder 'Discrete')
+```
+Als `Distributions` nog niet in de bovenbalk staat kun je dit toevoegen door rechtsbovenin op de blauwe **+**-button te klikken en `Distributions` aan te vinken.\ 
+In de "Binomial" invoer is de balk `Show Distribution` als het goed is open. Pas hier de waarden voor $p$ (onder "free parameter") en $n$ (onder "Fixed parameter") aan naar $p=0.38$ en $n=3$. Pas onder "Options" ook de range aan naar `Range of $x$ from $0$ to $3$`. Onder "Display" moet `Probability mass function` aangevinkt zijn. In de uitvoer zie je onder *Probability Mass Plot* de binomiale kansverdeling. 
+
 ### R
 
 ```{r binomkansverdeling3.dbinom}

--- a/h10kansverdelingen.Rmd
+++ b/h10kansverdelingen.Rmd
@@ -608,9 +608,14 @@ uitvoer bevat eerst de resultaten van de Shapiro-Wilks-toets en de
 Kolmogorov-Smirnov toets. Volgens beide toetsen is de kans om deze
 verdeling te vinden, als H0 waar is, bijna nul --- zie echter de
 waarschuwing in
-§\@ref(#sec:pgroterdannul)! We verwerpen daarom H0 en concluderen
+§ \@ref(#sec:pgroterdannul)! We verwerpen daarom H0 en concluderen
 dat de duren van muzieknummers niet normaal verdeeld zijn. Na deze
 toetsresultaten volgt o.a. een QQ-plot.
+
+### JASP
+
+Klik in de bovenbalk op `Descriptives` en selecteer variabele Time in het veld "Variables". Klik de balk `Plots` open en vink `Distribution plots` aan onder "Basic plots" voor een histogram. Vink ook `Q-Q plots` aan voor een quantile-quantile plot. Klik vervolgens de balk `Statistics` open en vink `Shapiro-Wilk test` aan onder "Distribution".\
+De uitvoer geeft de uitkomst van de Shapiro-Wilk-toets in de tabel *Descriptive Statistics*. We zien dat de kans om deze verdeling te vinden, als H0 waar is, bijna nul is. H0 wordt dus verworpen en we concluderen dat de duren van de muzieknummers niet normaal verdeeld zijn. Dit kun je ook terugzien in de histogram en Q-Q plot. 
 
 ### R
 

--- a/h10kansverdelingen.Rmd
+++ b/h10kansverdelingen.Rmd
@@ -615,7 +615,7 @@ toetsresultaten volgt o.a. een QQ-plot.
 ### JASP
 
 Klik in de bovenbalk op `Descriptives` en selecteer variabele Time in het veld "Variables". Klik de balk `Plots` open en vink `Distribution plots` aan onder "Basic plots" voor een histogram. Vink ook `Q-Q plots` aan voor een quantile-quantile plot. Klik vervolgens de balk `Statistics` open en vink `Shapiro-Wilk test` aan onder "Distribution".\
-De uitvoer geeft de uitkomst van de Shapiro-Wilk-toets in de tabel *Descriptive Statistics*. We zien dat de kans om deze verdeling te vinden, als H0 waar is, bijna nul is. H0 wordt dus verworpen en we concluderen dat de duren van de muzieknummers niet normaal verdeeld zijn. Dit kun je ook terugzien in de histogram en Q-Q plot. 
+De uitvoer geeft de uitkomst van de Shapiro-Wilk-toets in de tabel *Descriptive Statistics*. We zien dat de kans om deze verdeling te vinden, als H0 waar is, bijna nul is. H0 wordt dus verworpen en we concluderen dat de duren van de muzieknummers niet normaal verdeeld zijn. Dit kun je ook terugzien in het histogram en de Q-Q plot. 
 
 ### R
 

--- a/h10kansverdelingen.Rmd
+++ b/h10kansverdelingen.Rmd
@@ -608,7 +608,7 @@ uitvoer bevat eerst de resultaten van de Shapiro-Wilks-toets en de
 Kolmogorov-Smirnov toets. Volgens beide toetsen is de kans om deze
 verdeling te vinden, als H0 waar is, bijna nul --- zie echter de
 waarschuwing in
-§ \@ref(#sec:pgroterdannul)! We verwerpen daarom H0 en concluderen
+§\@ref(sec:pgroterdannul)! We verwerpen daarom H0 en concluderen
 dat de duren van muzieknummers niet normaal verdeeld zijn. Na deze
 toetsresultaten volgt o.a. een QQ-plot.
 

--- a/h10kansverdelingen.Rmd
+++ b/h10kansverdelingen.Rmd
@@ -522,6 +522,16 @@ $\mu=0$ en standaarddeviatie $\sigma=1$ is
   (\#eq:prob-standaardnormaal)
 \end{equation}
 
+### JASP
+
+De normale kansverdeling van Figuur \@ref(fig:normaalkansverdeling) kan in JASP worden verkregen door in de bovenbalk te klikken op:
+```
+Distributions > Normal (onder 'Continuous')
+```
+Als `Distributions` nog niet in de bovenbalk staat kun je dit toevoegen door rechtsbovenin op de blauwe **+**-button te klikken en `Distributions` aan te vinken.\ 
+In de "Normal" invoer is de balk `Show Distribution` als het goed is open. Automatisch staan de waarden voor de standaard-normale kansverdeling al ingevuld en `Probability density function` aangevinkt; je ziet deze verdeling dus meteen in de uitvoer onder *Density Plot*. \
+Voor andere normale kansverdelingen kunnen de waarden voor $\mu$ en $\sigma$ worden aangepast, en ook de range die wordt weergegeven (onder "Options"). Let op dat je bij "Parameters" `$\mu$, $\sigma$` selecteert als je het gemiddelde en de standaarddeviatie ingeeft (voor de standaard-normale kansverdeling maakt dit niet uit, want bij $\sigma=1$ geldt ook $\sigma^2=1$). 
+
 ## Heeft mijn variabele een normale kansverdeling? {#sec:isvarnormaalverdeeld}
 
 ```{r itunestimeshist-prep, echo=FALSE}


### PR DESCRIPTION
I also added JASP instructions in sections 10.2 and 10.3. 

Section 10.2 (binomial distribution) already had an R section (no SPSS). Section 10.3 (normal distribution) had no R (and SPSS) section, but I added a JASP section because I think that would make sense if we also have this for 10.2. 

Maybe it's a good idea to also add an R section in 10.3. Then both (binomial & normal) have R and JASP instructions. SPSS could also be added for both sections (e.g. transform > compute variable.. use pdf.binomial function), but that may be a bit too much/complicated?